### PR TITLE
fix(index): use readFileSync and JSON.parse for `.huskyrc` file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { existsSync, writeFileSync } = require('fs');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
 const { execSync } = require('child_process');
 const { resolve } = require('path');
 
@@ -81,7 +81,7 @@ if (packageJson.husky) {
   husky = packageJson.husky;
   delete packageJson.husky;
 } else if (existsSync(huskyrcPath)) {
-  husky = require(huskyrcPath);
+  husky = JSON.parse(readFileSync(huskyrcPath));
   exec(`git rm ${huskyrcPath}`);
 } else if (existsSync(huskyrcJsonPath)) {
   husky = require(huskyrcJsonPath);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(index): use readFileSync and JSON.parse for `.huskyrc` file

```sh
$ npx husky-4-to-5
npx: installed 1 in 1.318s
INFO: husky-4-to-5 v1.1.0
Unexpected token ':'
INFO: Exited with code: 1
```

## What is the current behavior?

Fails for `.huskyrc`

## What is the new behavior?

Succeeds for `.huskyrc`

## Checklist:

- [ ] Tests
- [ ] Documentation
