### PR TITLE
fix: fix husky command with $1 and path

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,9 @@
   "extends": ["plugin:@typescript-eslint/recommended"],
   "plugins": ["@typescript-eslint", "prettier"],
   "rules": {
+    "@typescript-eslint/no-unused-vars": ["error"],
     "no-debugger": "error",
+    "no-unused-vars": "off",
     "prettier/prettier": "error"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import { resolve } from 'path';
 import { name, version } from '../package.json';
 import { HUSKY_VERSION } from './constants';
 import { cwd, exec, log, write } from './utilities';
-import type { JSONValue } from './types';
 
 /**
  * Display exit code.

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,13 +112,18 @@ log('Adding hooks...');
 exec(`npx ${huskyInstall}`);
 
 Object.entries(husky.hooks).forEach(([hook, command]) => {
-  command = command
-    .replace(/-E HUSKY_GIT_PARAMS/g, '--edit $1')
-    .replace(/HUSKY_GIT_PARAMS/g, '$1');
-  exec(`npx husky add .husky/${hook} '${command}'`);
+  if (/HUSKY_GIT_PARAMS/.test(command)) {
+    exec(`npx husky set .husky/${hook} ''`);
+    command = command
+      .replace(/-E HUSKY_GIT_PARAMS/g, '--edit $1')
+      .replace(/HUSKY_GIT_PARAMS/g, '$1');
+    exec(`echo '${command}' >> .husky/${hook}`);
+  } else {
+    exec(`npx husky set .husky/${hook} '${command}'`);
+  }
 });
 
-isGitRepository && exec('git add .husky/');
+isGitRepository && exec('git add .husky');
 
 /**
  * Commit changes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { join } from 'path';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -35,7 +35,7 @@ try {
 /**
  * Require `package.json`.
  */
-const packageJsonPath = resolve(cwd, 'package.json');
+const packageJsonPath = join(cwd, 'package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require(packageJsonPath);
 
@@ -46,10 +46,10 @@ let husky: { hooks: Record<string, string> } = {
   hooks: {}
 };
 
-const huskyrcPath = resolve(cwd, '.huskyrc');
-const huskyrcJsonPath = resolve(cwd, '.huskyrc.json');
-const huskyrcJsPath = resolve(cwd, '.huskyrc.js');
-const huskyConfigJsPath = resolve(cwd, 'husky.config.js');
+const huskyrcPath = join(cwd, '.huskyrc');
+const huskyrcJsonPath = join(cwd, '.huskyrc.json');
+const huskyrcJsPath = join(cwd, '.huskyrc.js');
+const huskyConfigJsPath = join(cwd, 'husky.config.js');
 
 if (packageJson.husky) {
   husky = packageJson.husky;
@@ -112,14 +112,16 @@ log('Adding hooks...');
 exec(`npx ${huskyInstall}`);
 
 Object.entries(husky.hooks).forEach(([hook, command]) => {
+  const huskyHookPath = join('.husky', hook);
+
   if (/HUSKY_GIT_PARAMS/.test(command)) {
-    exec(`npx husky set .husky/${hook} ''`);
+    exec(`npx husky set ${huskyHookPath} ''`);
     command = command
       .replace(/-E HUSKY_GIT_PARAMS/g, '--edit $1')
       .replace(/HUSKY_GIT_PARAMS/g, '$1');
-    exec(`echo '${command}' >> .husky/${hook}`);
+    exec(`echo '${command}' >> ${huskyHookPath}`);
   } else {
-    exec(`npx husky set .husky/${hook} '${command}'`);
+    exec(`npx husky set ${huskyHookPath} '${command}'`);
   }
 });
 


### PR DESCRIPTION
## What is the motivation for this pull request?

- fix: fix husky command with $1
- fix: ensure path works on other OS (e.g., Windows)

## What is the current behavior?

$1 is stripped out due to npm behavior:

```sh
npx husky add .husky/hook '$1'
```

CLI only works on *nix OS

## What is the new behavior?

$1 is no longer stripped out:

```sh
npx husky add .husky/hook '$1'
```

CLI works on Windows