### PR TITLE
fix(package): run build in prepublishOnly and tidy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",
     "lint:tsc": "tsc -p src/tsconfig.json --noEmit",
-    "postinstall": "husky install && husky install && husky install && husky install && husky install",
-    "postpublish": "pinst --enable && pinst --enable && pinst --enable && pinst --enable && pinst --enable",
-    "prepublishOnly": "pinst --disable && pinst --disable && pinst --disable && pinst --disable && pinst --disable",
+    "postinstall": "husky install",
+    "postpublish": "pinst --enable",
+    "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run clean && npm run build",
     "test": "jest --detectOpenHandles"
   },
   "repository": {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): run build in prepublishOnly and tidy scripts

## What is the current behavior?

```
$ npx husky-4-to-5@1.2.1
sh: husky-4-to-5: command not found
```

## What is the new behavior?

Build files are published to npm

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation