### PR TITLE
feat(bin): check whether project is using npm or yarn

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -99,11 +99,20 @@ if (!packageJson.private) {
 write(packageJsonPath, packageJson);
 
 /**
+ * Check whether project is using npm or yarn.
+ */
+const hasYarn = existsSync('yarn.lock');
+
+/**
  * Install dependencies.
  */
 log('Installing devDependencies...');
 
-exec(`npm install --save-dev ${devDependencies.join(' ')}`);
+if (hasYarn) {
+  exec(`yarn add --dev ${devDependencies.join(' ')}`);
+} else {
+  exec(`npm install --save-dev ${devDependencies.join(' ')}`);
+}
 
 if (isGitRepository) {
   exec('git add package.json');


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(bin): check whether project is using npm or yarn

## What is the current behavior?

Only npm install is used

## What is the new behavior?

If `yarn.lock` exists, then use yarn to save devDependencies; otherwise, use npm

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation